### PR TITLE
fixes keyboard hiding last clues

### DIFF
--- a/app/src/main/java/com/jhb/crosswordScan/ui/solveScreen/PuzzleSolveViewModel.kt
+++ b/app/src/main/java/com/jhb/crosswordScan/ui/solveScreen/PuzzleSolveViewModel.kt
@@ -52,6 +52,13 @@ class PuzzleSolveViewModel(private val repository: PuzzleRepository,private val 
         Log.i(TAG,"Finished initialising ui")
     }
 
+    fun toggleCollapseKeyboard(){
+        _uiState.update { ui ->
+            ui.copy(keyboardCollapsed = !_uiState.value.keyboardCollapsed,
+            )
+        }
+    }
+
 
     fun convertPuzzleToCellSet(puzzle : Puzzle) : MutableSet<Triple<Int, Int, String>>{
         val cellSet = mutableSetOf<Triple<Int, Int, String>>()

--- a/app/src/main/java/com/jhb/crosswordScan/ui/solveScreen/PuzzleUiState.kt
+++ b/app/src/main/java/com/jhb/crosswordScan/ui/solveScreen/PuzzleUiState.kt
@@ -10,5 +10,6 @@ data class PuzzleUiState (
     val currentCell : Triple<Int,Int,String> = Triple(-1,-1,""),
     val currentClue : Clue = Clue("noname", mutableListOf<Triple<Int,Int,String>>() ),
     val updateFromRepository : Boolean = true,
-    val puzzleId : String? = null
+    val puzzleId : String? = null,
+    val keyboardCollapsed : Boolean = false,
 )


### PR DESCRIPTION
the clues used to be constrained to the bottom of the container. This meant the keyboard would cover clues at the bottom of the list. Now I've introduced a new UI state the represents if the keyboard is collapsed and a function to toggle this state. Based on this, the positioning of the clue list can be apapted for each state